### PR TITLE
Basic Todo test 코드 구현

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,12 +6,18 @@ const createJestConfig = nextJest({ dir: '.' });
  * @type {import('@jest/types').Config.InitialOptions}
  */
 const customJestConfig = {
+  roots: ['<rootDir>'],
   collectCoverageFrom: ['src/**/*.@(j|t)s?(x)'],
   coveragePathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/src\\/types/',
   ],
-  moduleNameMapper: {},
+
+  modulePaths: ['<rootDir>'],
+  moduleNameMapper: {
+    '@src/(.*)': ['<rootDir>/src/$1'],
+  },
+  moduleDirectories: ['node_modules'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jsdom',
 };

--- a/src/components/todoList/todoList.test.tsx
+++ b/src/components/todoList/todoList.test.tsx
@@ -1,0 +1,36 @@
+import { todoState } from '@src/recoil';
+import { TodoListType } from '@src/types';
+import { render, screen } from '@testing-library/react';
+import { useRecoilValue } from 'recoil';
+import { v4 as uuidv4 } from 'uuid';
+
+import TodoList from './TodoList';
+
+jest.mock('recoil');
+jest.mock('uuid');
+
+describe('TodoList test', () => {
+  beforeAll(() => {
+    (useRecoilValue as jest.Mock).mockImplementation((selector) => {
+      if (selector === todoState) {
+        return [
+          { title: 'Todo 1' },
+          { title: 'Todo 2' },
+          { title: 'Todo 3' },
+        ] as TodoListType;
+      }
+    });
+    (uuidv4 as jest.Mock).mockImplementation(() => {
+      return '1';
+    });
+  });
+
+  test('check title', async () => {
+    render(<TodoList />);
+    const dragableBoxes = screen.getAllByTestId('dragable-box');
+
+    expect(dragableBoxes[0]).toHaveTextContent('Todo 1');
+    expect(dragableBoxes[1]).toHaveTextContent('Todo 2');
+    expect(dragableBoxes[2]).toHaveTextContent('Todo 3');
+  });
+});

--- a/src/components/todoform/todoform.test.tsx
+++ b/src/components/todoform/todoform.test.tsx
@@ -1,0 +1,21 @@
+import { todoState } from '../../recoil/index';
+import { TodoFormRecoilObserverProps, TodoListType } from '@src/types';
+import userEvent from '@testing-library/user-event';
+import { render, renderHook, screen } from '@testing-library/react';
+import { RecoilRoot, useRecoilValue } from 'recoil';
+
+import TodoForm from './todoform';
+
+test('TodoForm  Test', async () => {
+  const { queryByPlaceholderText, getByText } = render(
+    <RecoilRoot>
+      <TodoForm />
+    </RecoilRoot>
+  );
+
+  expect(queryByPlaceholderText('todo 제목을 입력해주세요')).toHaveAttribute(
+    'placeholder',
+    'todo 제목을 입력해주세요'
+  );
+  expect(getByText('add')).toHaveTextContent('add');
+});

--- a/src/components/todoform/todoform.tsx
+++ b/src/components/todoform/todoform.tsx
@@ -5,25 +5,20 @@ import { Todo, TodoListType } from '../../types';
 import Input from '../../userInterface/input/input';
 import { FC } from 'react';
 import { useRecoilState } from 'recoil';
+import useTodo from '@src/hooks/useTodo';
 
 const TodoForm: FC = () => {
   const { value, onChange } = useInput('');
-  const [todo, setTodo] = useRecoilState<TodoListType>(todoState);
+  const { addTodo } = useTodo();
 
-  const addTodoHandler = () => {
-    const tempTodo: Todo = {
-      id: todo.length + 1,
-      title: value,
-      status: 'todo',
-    };
-
-    setTodo([...todo, tempTodo]);
+  const clickAddHandler = () => {
+    addTodo(value);
   };
 
   return (
     <>
       <Input placeholder='todo 제목을 입력해주세요' onChange={onChange} />
-      <Button label='add' onClick={addTodoHandler} />
+      <Button label='add' onClick={clickAddHandler} />
     </>
   );
 };

--- a/src/hooks/useInput.test.tsx
+++ b/src/hooks/useInput.test.tsx
@@ -1,0 +1,21 @@
+import { render, renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { useInput } from './useInput';
+
+describe('useInput Test', () => {
+  test('onChange function unit test', async () => {
+    const { result } = renderHook(() => useInput(''), {});
+    const { onChange, value } = result.current;
+    const { getByPlaceholderText } = render(
+      <input onChange={onChange} placeholder='test' />
+    );
+    expect(value).toEqual('');
+
+    const input = getByPlaceholderText('test');
+    await userEvent.type(input, 'This is a test');
+    const currentValue = result.current.value;
+
+    expect(currentValue).toEqual('This is a test');
+  });
+});

--- a/src/hooks/useTodo.test.ts
+++ b/src/hooks/useTodo.test.ts
@@ -1,0 +1,31 @@
+import { act, renderHook } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+import { initailTodo } from '@src/recoil';
+import useTodo from './useTodo';
+
+describe('useTodo Test', () => {
+  test('addTodo function unit test', () => {
+    const { result } = renderHook(() => useTodo(), {
+      wrapper: RecoilRoot,
+    });
+
+    const { todo, addTodo } = result.current;
+
+    expect(todo).toEqual(initailTodo);
+
+    act(() => {
+      addTodo('Test');
+    });
+
+    const todoList = [
+      ...initailTodo,
+      {
+        id: 3,
+        status: 'todo',
+        title: 'Test',
+      },
+    ];
+    expect(result.current.todo).toEqual(todoList);
+  });
+});

--- a/src/hooks/useTodo.ts
+++ b/src/hooks/useTodo.ts
@@ -1,0 +1,22 @@
+import { useRecoilState } from 'recoil';
+
+import { todoState } from '@src/recoil';
+import { Todo, TodoListType } from '@src/types';
+
+const useTodo = () => {
+  const [todo, setTodo] = useRecoilState<TodoListType>(todoState);
+
+  const addTodo = (value: string) => {
+    const tempTodo: Todo = {
+      id: todo.length + 1,
+      title: value,
+      status: 'todo',
+    };
+
+    setTodo([...todo, tempTodo]);
+  };
+
+  return { addTodo, todo };
+};
+
+export default useTodo;

--- a/src/recoil/index.ts
+++ b/src/recoil/index.ts
@@ -1,20 +1,22 @@
 import { atom } from 'recoil';
 import { TodoListType } from '@src/types';
 
+export const initailTodo = [
+  {
+    id: 1,
+    title: 'todo 1',
+    content: 'Initial Content by Han',
+    status: 'todo',
+  },
+  {
+    id: 2,
+    title: 'todo 2',
+    content: 'Second Content by Han',
+    status: 'todo',
+  },
+];
+
 export const todoState = atom<TodoListType>({
   key: 'todoList',
-  default: [
-    {
-      id: 1,
-      title: 'todo 1',
-      content: 'Initial Content by Han',
-      status: 'todo',
-    },
-    {
-      id: 2,
-      title: 'todo 2',
-      content: 'Second Content by Han',
-      status: 'todo',
-    },
-  ],
+  default: initailTodo,
 });

--- a/src/userInterface/button/button.test.tsx
+++ b/src/userInterface/button/button.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 
-import Button from './Button';
+import Button from './button';
 
-test('Button', () => {
+test('Button test', () => {
   render(<Button label='Button' />);
 
   expect(screen.getByText('Button')).toHaveTextContent('Button');

--- a/src/userInterface/input/input.test.tsx
+++ b/src/userInterface/input/input.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+
+import Input from './input';
+
+test('Button test', () => {
+  render(<Input placeholder='test' />);
+
+  expect(screen.queryByPlaceholderText('test')).toHaveAttribute(
+    'placeholder',
+    'test'
+  );
+});


### PR DESCRIPTION
## 개요 OR 이유
- 연관 이슈 : https://github.com/hkh0105/bank_salad_mine/issues/2
- 해결 방법 및 이유: 컴포넌트 별 Unit 테스트를 하고, recoil과 uuid의 경우 mocking을 하여 테스트했다.
todoform 컴포넌트의 리코일 상태를 직접적으로 업데이트 하는 addTodo 함수는 useTodo라는 커스텀 훅으로 분리하여 테스트를 진행했다.
이렇게 분리 시 테스트 하기 쉬울 뿐 아니라, todo 관련 훅들의 확장성과, 재사용성도 높아진다.

## 주요 변경점 OR Screenshot

- Input, Button unit test 코드 구현
- useTodo test 코드 구현
- useInput test 코드 구현
- todoform test 코드 구현
- todoList test 코드 구현